### PR TITLE
Redirect goodbye page to marksandspencer.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 >
   <head>
     <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0;url=https://www.marksandspencer.com/">
 
     <title>Goodbye | Thread</title>
 


### PR DESCRIPTION
This feels like the best way of achieving the redirect without changing any DNS for now. We still rely on email etc. so we don't want to change anything wholesale.